### PR TITLE
Configurable Seam API Url (for Browser REPL)

### DIFF
--- a/docs/classes/SeamAPIError.md
+++ b/docs/classes/SeamAPIError.md
@@ -48,7 +48,7 @@ Error.constructor
 
 #### Defined in
 
-[src/lib/api-error.ts:8](https://github.com/seamapi/seamapi-javascript/blob/main/src/lib/api-error.ts#L8)
+[src/lib/api-error.ts:8](https://github.com/hello-seam/seamapi-javascript/blob/main/src/lib/api-error.ts#L8)
 
 ## Properties
 
@@ -163,7 +163,7 @@ node_modules/@types/node/globals.d.ts:13
 
 #### Defined in
 
-[src/lib/api-error.ts:16](https://github.com/seamapi/seamapi-javascript/blob/main/src/lib/api-error.ts#L16)
+[src/lib/api-error.ts:16](https://github.com/hello-seam/seamapi-javascript/blob/main/src/lib/api-error.ts#L16)
 
 ___
 

--- a/docs/classes/SeamActionAttemptError.md
+++ b/docs/classes/SeamActionAttemptError.md
@@ -49,7 +49,7 @@ Error.constructor
 
 #### Defined in
 
-[src/lib/api-error.ts:22](https://github.com/seamapi/seamapi-javascript/blob/main/src/lib/api-error.ts#L22)
+[src/lib/api-error.ts:22](https://github.com/hello-seam/seamapi-javascript/blob/main/src/lib/api-error.ts#L22)
 
 ## Properties
 
@@ -160,7 +160,7 @@ node_modules/@types/node/globals.d.ts:13
 
 #### Defined in
 
-[src/lib/api-error.ts:34](https://github.com/seamapi/seamapi-javascript/blob/main/src/lib/api-error.ts#L34)
+[src/lib/api-error.ts:34](https://github.com/hello-seam/seamapi-javascript/blob/main/src/lib/api-error.ts#L34)
 
 ___
 

--- a/docs/classes/default.md
+++ b/docs/classes/default.md
@@ -37,10 +37,10 @@
 
 #### Parameters
 
-| Name | Type | Default value |
-| :------ | :------ | :------ |
-| `apiKey?` | `string` | `undefined` |
-| `endpoint` | `string` | `"https://connect.getseam.com"` |
+| Name | Type |
+| :------ | :------ |
+| `apiKey?` | `string` |
+| `endpoint` | `string` |
 
 #### Overrides
 
@@ -48,7 +48,7 @@ Routes.constructor
 
 #### Defined in
 
-[src/index.ts:9](https://github.com/seamapi/seamapi-javascript/blob/main/src/index.ts#L9)
+[src/index.ts:9](https://github.com/hello-seam/seamapi-javascript/blob/main/src/index.ts#L9)
 
 ## Properties
 
@@ -70,7 +70,7 @@ Routes.accessCodes
 
 #### Defined in
 
-[src/routes.ts:190](https://github.com/seamapi/seamapi-javascript/blob/main/src/routes.ts#L190)
+[src/routes.ts:190](https://github.com/hello-seam/seamapi-javascript/blob/main/src/routes.ts#L190)
 
 ___
 
@@ -90,7 +90,7 @@ Routes.actionAttempts
 
 #### Defined in
 
-[src/routes.ts:262](https://github.com/seamapi/seamapi-javascript/blob/main/src/routes.ts#L262)
+[src/routes.ts:262](https://github.com/hello-seam/seamapi-javascript/blob/main/src/routes.ts#L262)
 
 ___
 
@@ -100,7 +100,7 @@ ___
 
 #### Defined in
 
-[src/index.ts:7](https://github.com/seamapi/seamapi-javascript/blob/main/src/index.ts#L7)
+[src/index.ts:7](https://github.com/hello-seam/seamapi-javascript/blob/main/src/index.ts#L7)
 
 ___
 
@@ -122,7 +122,7 @@ Routes.connectWebviews
 
 #### Defined in
 
-[src/routes.ts:164](https://github.com/seamapi/seamapi-javascript/blob/main/src/routes.ts#L164)
+[src/routes.ts:164](https://github.com/hello-seam/seamapi-javascript/blob/main/src/routes.ts#L164)
 
 ___
 
@@ -143,7 +143,7 @@ Routes.connectedAccounts
 
 #### Defined in
 
-[src/routes.ts:241](https://github.com/seamapi/seamapi-javascript/blob/main/src/routes.ts#L241)
+[src/routes.ts:241](https://github.com/hello-seam/seamapi-javascript/blob/main/src/routes.ts#L241)
 
 ___
 
@@ -164,7 +164,7 @@ Routes.devices
 
 #### Defined in
 
-[src/routes.ts:145](https://github.com/seamapi/seamapi-javascript/blob/main/src/routes.ts#L145)
+[src/routes.ts:145](https://github.com/hello-seam/seamapi-javascript/blob/main/src/routes.ts#L145)
 
 ___
 
@@ -187,7 +187,7 @@ Routes.locks
 
 #### Defined in
 
-[src/routes.ts:110](https://github.com/seamapi/seamapi-javascript/blob/main/src/routes.ts#L110)
+[src/routes.ts:110](https://github.com/hello-seam/seamapi-javascript/blob/main/src/routes.ts#L110)
 
 ___
 
@@ -209,7 +209,7 @@ Routes.workspaces
 
 #### Defined in
 
-[src/routes.ts:94](https://github.com/seamapi/seamapi-javascript/blob/main/src/routes.ts#L94)
+[src/routes.ts:94](https://github.com/hello-seam/seamapi-javascript/blob/main/src/routes.ts#L94)
 
 ## Methods
 
@@ -239,4 +239,4 @@ Routes.makeRequest
 
 #### Defined in
 
-[src/index.ts:30](https://github.com/seamapi/seamapi-javascript/blob/main/src/index.ts#L30)
+[src/index.ts:33](https://github.com/hello-seam/seamapi-javascript/blob/main/src/index.ts#L33)

--- a/docs/enums/Provider.md
+++ b/docs/enums/Provider.md
@@ -20,7 +20,7 @@
 
 #### Defined in
 
-[src/types/models.ts:17](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L17)
+[src/types/models.ts:17](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L17)
 
 ___
 
@@ -30,7 +30,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:20](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L20)
+[src/types/models.ts:20](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L20)
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:18](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L18)
+[src/types/models.ts:18](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L18)
 
 ___
 
@@ -50,7 +50,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:21](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L21)
+[src/types/models.ts:21](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L21)
 
 ___
 
@@ -60,4 +60,4 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:19](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L19)
+[src/types/models.ts:19](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L19)

--- a/docs/interfaces/APIErrorResponse.md
+++ b/docs/interfaces/APIErrorResponse.md
@@ -18,7 +18,7 @@
 
 #### Defined in
 
-[src/types/globals.ts:4](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/globals.ts#L4)
+[src/types/globals.ts:4](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/globals.ts#L4)
 
 ___
 
@@ -28,7 +28,7 @@ ___
 
 #### Defined in
 
-[src/types/globals.ts:3](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/globals.ts#L3)
+[src/types/globals.ts:3](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/globals.ts#L3)
 
 ___
 
@@ -38,4 +38,4 @@ ___
 
 #### Defined in
 
-[src/types/globals.ts:2](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/globals.ts#L2)
+[src/types/globals.ts:2](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/globals.ts#L2)

--- a/docs/interfaces/AccessCodeBase.md
+++ b/docs/interfaces/AccessCodeBase.md
@@ -26,7 +26,7 @@
 
 #### Defined in
 
-[src/types/models.ts:124](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L124)
+[src/types/models.ts:124](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L124)
 
 ___
 
@@ -36,7 +36,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:126](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L126)
+[src/types/models.ts:126](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L126)
 
 ___
 
@@ -46,4 +46,4 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:125](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L125)
+[src/types/models.ts:125](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L125)

--- a/docs/interfaces/AccessCodeCreateBaseRequest.md
+++ b/docs/interfaces/AccessCodeCreateBaseRequest.md
@@ -24,7 +24,7 @@
 
 #### Defined in
 
-[src/types/route-requests.ts:10](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-requests.ts#L10)
+[src/types/route-requests.ts:10](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/route-requests.ts#L10)
 
 ___
 
@@ -34,7 +34,7 @@ ___
 
 #### Defined in
 
-[src/types/route-requests.ts:8](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-requests.ts#L8)
+[src/types/route-requests.ts:8](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/route-requests.ts#L8)
 
 ___
 
@@ -44,4 +44,4 @@ ___
 
 #### Defined in
 
-[src/types/route-requests.ts:9](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-requests.ts#L9)
+[src/types/route-requests.ts:9](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/route-requests.ts#L9)

--- a/docs/interfaces/AccessCodeCreateScheduledRequest.md
+++ b/docs/interfaces/AccessCodeCreateScheduledRequest.md
@@ -30,7 +30,7 @@
 
 #### Defined in
 
-[src/types/route-requests.ts:10](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-requests.ts#L10)
+[src/types/route-requests.ts:10](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/route-requests.ts#L10)
 
 ___
 
@@ -44,7 +44,7 @@ ___
 
 #### Defined in
 
-[src/types/route-requests.ts:8](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-requests.ts#L8)
+[src/types/route-requests.ts:8](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/route-requests.ts#L8)
 
 ___
 
@@ -54,7 +54,7 @@ ___
 
 #### Defined in
 
-[src/types/route-requests.ts:18](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-requests.ts#L18)
+[src/types/route-requests.ts:18](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/route-requests.ts#L18)
 
 ___
 
@@ -68,7 +68,7 @@ ___
 
 #### Defined in
 
-[src/types/route-requests.ts:9](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-requests.ts#L9)
+[src/types/route-requests.ts:9](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/route-requests.ts#L9)
 
 ___
 
@@ -78,4 +78,4 @@ ___
 
 #### Defined in
 
-[src/types/route-requests.ts:17](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-requests.ts#L17)
+[src/types/route-requests.ts:17](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/route-requests.ts#L17)

--- a/docs/interfaces/AccessCodesListResponse.md
+++ b/docs/interfaces/AccessCodesListResponse.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[src/types/route-responses.ts:57](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-responses.ts#L57)
+[src/types/route-responses.ts:57](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/route-responses.ts#L57)

--- a/docs/interfaces/ActionAttemptCreateResponse.md
+++ b/docs/interfaces/ActionAttemptCreateResponse.md
@@ -22,4 +22,4 @@
 
 #### Defined in
 
-[src/types/route-responses.ts:73](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-responses.ts#L73)
+[src/types/route-responses.ts:73](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/route-responses.ts#L73)

--- a/docs/interfaces/ActionAttemptGetResponse.md
+++ b/docs/interfaces/ActionAttemptGetResponse.md
@@ -22,4 +22,4 @@
 
 #### Defined in
 
-[src/types/route-responses.ts:77](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-responses.ts#L77)
+[src/types/route-responses.ts:77](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/route-responses.ts#L77)

--- a/docs/interfaces/ActionAttemptResultTypeMap.md
+++ b/docs/interfaces/ActionAttemptResultTypeMap.md
@@ -35,7 +35,7 @@ Record.CREATE\_ACCESS\_CODE
 
 #### Defined in
 
-[src/types/models.ts:92](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L92)
+[src/types/models.ts:92](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L92)
 
 ___
 

--- a/docs/interfaces/ActionAttemptWithError.md
+++ b/docs/interfaces/ActionAttemptWithError.md
@@ -36,7 +36,7 @@ ActionAttemptBase.action\_attempt\_id
 
 #### Defined in
 
-[src/types/models.ts:66](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L66)
+[src/types/models.ts:66](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L66)
 
 ___
 
@@ -50,7 +50,7 @@ ActionAttemptBase.action\_type
 
 #### Defined in
 
-[src/types/models.ts:67](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L67)
+[src/types/models.ts:67](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L67)
 
 ___
 
@@ -71,7 +71,7 @@ ActionAttemptBase.error
 
 #### Defined in
 
-[src/types/models.ts:84](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L84)
+[src/types/models.ts:84](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L84)
 
 ___
 
@@ -85,7 +85,7 @@ ActionAttemptBase.result
 
 #### Defined in
 
-[src/types/models.ts:83](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L83)
+[src/types/models.ts:83](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L83)
 
 ___
 
@@ -99,4 +99,4 @@ ActionAttemptBase.status
 
 #### Defined in
 
-[src/types/models.ts:82](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L82)
+[src/types/models.ts:82](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L82)

--- a/docs/interfaces/ConnectWebview.md
+++ b/docs/interfaces/ConnectWebview.md
@@ -28,7 +28,7 @@
 
 #### Defined in
 
-[src/types/models.ts:112](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L112)
+[src/types/models.ts:112](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L112)
 
 ___
 
@@ -38,7 +38,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:111](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L111)
+[src/types/models.ts:111](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L111)
 
 ___
 
@@ -48,7 +48,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:114](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L114)
+[src/types/models.ts:114](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L114)
 
 ___
 
@@ -58,7 +58,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:113](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L113)
+[src/types/models.ts:113](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L113)
 
 ___
 
@@ -68,7 +68,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:108](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L108)
+[src/types/models.ts:108](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L108)
 
 ___
 
@@ -78,7 +78,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:118](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L118)
+[src/types/models.ts:118](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L118)
 
 ___
 
@@ -88,7 +88,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:115](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L115)
+[src/types/models.ts:115](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L115)
 
 ___
 
@@ -98,7 +98,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:119](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L119)
+[src/types/models.ts:119](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L119)
 
 ___
 
@@ -108,7 +108,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:110](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L110)
+[src/types/models.ts:110](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L110)
 
 ___
 
@@ -118,7 +118,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:116](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L116)
+[src/types/models.ts:116](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L116)
 
 ___
 
@@ -128,7 +128,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:117](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L117)
+[src/types/models.ts:117](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L117)
 
 ___
 
@@ -138,7 +138,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:120](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L120)
+[src/types/models.ts:120](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L120)
 
 ___
 
@@ -148,4 +148,4 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:109](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L109)
+[src/types/models.ts:109](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L109)

--- a/docs/interfaces/ConnectWebviewCreateRequest.md
+++ b/docs/interfaces/ConnectWebviewCreateRequest.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[src/types/route-requests.ts:4](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-requests.ts#L4)
+[src/types/route-requests.ts:4](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/route-requests.ts#L4)

--- a/docs/interfaces/ConnectWebviewCreateResponse.md
+++ b/docs/interfaces/ConnectWebviewCreateResponse.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[src/types/route-responses.ts:50](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-responses.ts#L50)
+[src/types/route-responses.ts:50](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/route-responses.ts#L50)

--- a/docs/interfaces/ConnectWebviewGetResponse.md
+++ b/docs/interfaces/ConnectWebviewGetResponse.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[src/types/route-responses.ts:47](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-responses.ts#L47)
+[src/types/route-responses.ts:47](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/route-responses.ts#L47)

--- a/docs/interfaces/ConnectWebviewsListResponse.md
+++ b/docs/interfaces/ConnectWebviewsListResponse.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[src/types/route-responses.ts:44](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-responses.ts#L44)
+[src/types/route-responses.ts:44](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/route-responses.ts#L44)

--- a/docs/interfaces/ConnectedAccount.md
+++ b/docs/interfaces/ConnectedAccount.md
@@ -19,7 +19,7 @@
 
 #### Defined in
 
-[src/types/models.ts:149](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L149)
+[src/types/models.ts:149](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L149)
 
 ___
 
@@ -29,7 +29,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:146](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L146)
+[src/types/models.ts:146](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L146)
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:147](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L147)
+[src/types/models.ts:147](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L147)
 
 ___
 
@@ -49,4 +49,4 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:148](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L148)
+[src/types/models.ts:148](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L148)

--- a/docs/interfaces/ConnectedAccountsGetResponse.md
+++ b/docs/interfaces/ConnectedAccountsGetResponse.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[src/types/route-responses.ts:65](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-responses.ts#L65)
+[src/types/route-responses.ts:65](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/route-responses.ts#L65)

--- a/docs/interfaces/ConnectedAccountsListResponse.md
+++ b/docs/interfaces/ConnectedAccountsListResponse.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[src/types/route-responses.ts:62](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-responses.ts#L62)
+[src/types/route-responses.ts:62](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/route-responses.ts#L62)

--- a/docs/interfaces/Device.md
+++ b/docs/interfaces/Device.md
@@ -30,7 +30,7 @@
 
 #### Defined in
 
-[src/types/models.ts:31](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L31)
+[src/types/models.ts:31](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L31)
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:30](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L30)
+[src/types/models.ts:30](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L30)
 
 ___
 
@@ -50,7 +50,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:32](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L32)
+[src/types/models.ts:32](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L32)
 
 ___
 
@@ -60,7 +60,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:25](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L25)
+[src/types/models.ts:25](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L25)
 
 ___
 
@@ -70,7 +70,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:29](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L29)
+[src/types/models.ts:29](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L29)
 
 ___
 
@@ -80,7 +80,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:28](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L28)
+[src/types/models.ts:28](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L28)
 
 ___
 
@@ -90,7 +90,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:27](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L27)
+[src/types/models.ts:27](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L27)
 
 ___
 
@@ -100,4 +100,4 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:26](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L26)
+[src/types/models.ts:26](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L26)

--- a/docs/interfaces/DeviceGetResponse.md
+++ b/docs/interfaces/DeviceGetResponse.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[src/types/route-responses.ts:39](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-responses.ts#L39)
+[src/types/route-responses.ts:39](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/route-responses.ts#L39)

--- a/docs/interfaces/DevicesListResponse.md
+++ b/docs/interfaces/DevicesListResponse.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[src/types/route-responses.ts:36](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-responses.ts#L36)
+[src/types/route-responses.ts:36](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/route-responses.ts#L36)

--- a/docs/interfaces/ErroredAPIResponse.md
+++ b/docs/interfaces/ErroredAPIResponse.md
@@ -17,7 +17,7 @@
 
 #### Defined in
 
-[src/types/globals.ts:13](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/globals.ts#L13)
+[src/types/globals.ts:13](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/globals.ts#L13)
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 #### Defined in
 
-[src/types/globals.ts:12](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/globals.ts#L12)
+[src/types/globals.ts:12](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/globals.ts#L12)

--- a/docs/interfaces/LockGetResponse.md
+++ b/docs/interfaces/LockGetResponse.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[src/types/route-responses.ts:31](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-responses.ts#L31)
+[src/types/route-responses.ts:31](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/route-responses.ts#L31)

--- a/docs/interfaces/LockProperties.md
+++ b/docs/interfaces/LockProperties.md
@@ -31,7 +31,7 @@
 
 #### Defined in
 
-[src/types/models.ts:47](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L47)
+[src/types/models.ts:47](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L47)
 
 ___
 
@@ -41,7 +41,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:39](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L39)
+[src/types/models.ts:39](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L39)
 
 ___
 
@@ -51,7 +51,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:40](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L40)
+[src/types/models.ts:40](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L40)
 
 ___
 
@@ -61,7 +61,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:37](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L37)
+[src/types/models.ts:37](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L37)
 
 ___
 
@@ -71,7 +71,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:36](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L36)
+[src/types/models.ts:36](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L36)
 
 ___
 
@@ -81,7 +81,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:38](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L38)
+[src/types/models.ts:38](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L38)
 
 ___
 
@@ -98,7 +98,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:42](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L42)
+[src/types/models.ts:42](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L42)
 
 ___
 
@@ -108,4 +108,4 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:53](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L53)
+[src/types/models.ts:53](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L53)

--- a/docs/interfaces/LocksListResponse.md
+++ b/docs/interfaces/LocksListResponse.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[src/types/route-responses.ts:27](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-responses.ts#L27)
+[src/types/route-responses.ts:27](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/route-responses.ts#L27)

--- a/docs/interfaces/OngoingAccessCode.md
+++ b/docs/interfaces/OngoingAccessCode.md
@@ -31,7 +31,7 @@
 
 #### Defined in
 
-[src/types/models.ts:124](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L124)
+[src/types/models.ts:124](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L124)
 
 ___
 
@@ -45,7 +45,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:126](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L126)
+[src/types/models.ts:126](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L126)
 
 ___
 
@@ -55,7 +55,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:131](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L131)
+[src/types/models.ts:131](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L131)
 
 ___
 
@@ -69,7 +69,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:125](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L125)
+[src/types/models.ts:125](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L125)
 
 ___
 
@@ -79,7 +79,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:132](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L132)
+[src/types/models.ts:132](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L132)
 
 ___
 
@@ -89,4 +89,4 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:130](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L130)
+[src/types/models.ts:130](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L130)

--- a/docs/interfaces/PendingActionAttempt.md
+++ b/docs/interfaces/PendingActionAttempt.md
@@ -36,7 +36,7 @@ ActionAttemptBase.action\_attempt\_id
 
 #### Defined in
 
-[src/types/models.ts:66](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L66)
+[src/types/models.ts:66](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L66)
 
 ___
 
@@ -50,7 +50,7 @@ ActionAttemptBase.action\_type
 
 #### Defined in
 
-[src/types/models.ts:67](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L67)
+[src/types/models.ts:67](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L67)
 
 ___
 
@@ -64,7 +64,7 @@ ActionAttemptBase.error
 
 #### Defined in
 
-[src/types/models.ts:77](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L77)
+[src/types/models.ts:77](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L77)
 
 ___
 
@@ -78,7 +78,7 @@ ActionAttemptBase.result
 
 #### Defined in
 
-[src/types/models.ts:76](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L76)
+[src/types/models.ts:76](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L76)
 
 ___
 
@@ -92,4 +92,4 @@ ActionAttemptBase.status
 
 #### Defined in
 
-[src/types/models.ts:75](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L75)
+[src/types/models.ts:75](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L75)

--- a/docs/interfaces/SeamAPIErrorMetadata.md
+++ b/docs/interfaces/SeamAPIErrorMetadata.md
@@ -18,7 +18,7 @@
 
 #### Defined in
 
-[src/lib/api-error.ts:4](https://github.com/seamapi/seamapi-javascript/blob/main/src/lib/api-error.ts#L4)
+[src/lib/api-error.ts:4](https://github.com/hello-seam/seamapi-javascript/blob/main/src/lib/api-error.ts#L4)
 
 ___
 
@@ -28,7 +28,7 @@ ___
 
 #### Defined in
 
-[src/lib/api-error.ts:3](https://github.com/seamapi/seamapi-javascript/blob/main/src/lib/api-error.ts#L3)
+[src/lib/api-error.ts:3](https://github.com/hello-seam/seamapi-javascript/blob/main/src/lib/api-error.ts#L3)
 
 ___
 
@@ -38,4 +38,4 @@ ___
 
 #### Defined in
 
-[src/lib/api-error.ts:2](https://github.com/seamapi/seamapi-javascript/blob/main/src/lib/api-error.ts#L2)
+[src/lib/api-error.ts:2](https://github.com/hello-seam/seamapi-javascript/blob/main/src/lib/api-error.ts#L2)

--- a/docs/interfaces/SuccessfulActionAttempt.md
+++ b/docs/interfaces/SuccessfulActionAttempt.md
@@ -36,7 +36,7 @@ ActionAttemptBase.action\_attempt\_id
 
 #### Defined in
 
-[src/types/models.ts:66](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L66)
+[src/types/models.ts:66](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L66)
 
 ___
 
@@ -50,7 +50,7 @@ ActionAttemptBase.action\_type
 
 #### Defined in
 
-[src/types/models.ts:67](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L67)
+[src/types/models.ts:67](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L67)
 
 ___
 
@@ -64,7 +64,7 @@ ActionAttemptBase.error
 
 #### Defined in
 
-[src/types/models.ts:98](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L98)
+[src/types/models.ts:98](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L98)
 
 ___
 
@@ -78,7 +78,7 @@ ActionAttemptBase.result
 
 #### Defined in
 
-[src/types/models.ts:99](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L99)
+[src/types/models.ts:99](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L99)
 
 ___
 
@@ -92,4 +92,4 @@ ActionAttemptBase.status
 
 #### Defined in
 
-[src/types/models.ts:97](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L97)
+[src/types/models.ts:97](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L97)

--- a/docs/interfaces/TimeBoundAccessCode.md
+++ b/docs/interfaces/TimeBoundAccessCode.md
@@ -33,7 +33,7 @@
 
 #### Defined in
 
-[src/types/models.ts:124](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L124)
+[src/types/models.ts:124](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L124)
 
 ___
 
@@ -47,7 +47,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:126](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L126)
+[src/types/models.ts:126](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L126)
 
 ___
 
@@ -57,7 +57,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:137](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L137)
+[src/types/models.ts:137](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L137)
 
 ___
 
@@ -67,7 +67,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:140](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L140)
+[src/types/models.ts:140](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L140)
 
 ___
 
@@ -81,7 +81,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:125](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L125)
+[src/types/models.ts:125](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L125)
 
 ___
 
@@ -91,7 +91,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:139](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L139)
+[src/types/models.ts:139](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L139)
 
 ___
 
@@ -101,7 +101,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:138](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L138)
+[src/types/models.ts:138](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L138)
 
 ___
 
@@ -111,4 +111,4 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:136](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L136)
+[src/types/models.ts:136](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L136)

--- a/docs/interfaces/Workspace.md
+++ b/docs/interfaces/Workspace.md
@@ -19,7 +19,7 @@
 
 #### Defined in
 
-[src/types/models.ts:3](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L3)
+[src/types/models.ts:3](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L3)
 
 ___
 
@@ -29,7 +29,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:5](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L5)
+[src/types/models.ts:5](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L5)
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:4](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L4)
+[src/types/models.ts:4](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L4)
 
 ___
 
@@ -49,4 +49,4 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:2](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L2)
+[src/types/models.ts:2](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L2)

--- a/docs/interfaces/WorkspaceGetResponse.md
+++ b/docs/interfaces/WorkspaceGetResponse.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[src/types/route-responses.ts:17](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-responses.ts#L17)
+[src/types/route-responses.ts:17](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/route-responses.ts#L17)

--- a/docs/interfaces/WorkspaceResetSandboxResponse.md
+++ b/docs/interfaces/WorkspaceResetSandboxResponse.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[src/types/route-responses.ts:22](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-responses.ts#L22)
+[src/types/route-responses.ts:22](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/route-responses.ts#L22)

--- a/docs/interfaces/WorkspacesListResponse.md
+++ b/docs/interfaces/WorkspacesListResponse.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[src/types/route-responses.ts:14](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-responses.ts#L14)
+[src/types/route-responses.ts:14](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/route-responses.ts#L14)

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -80,7 +80,7 @@
 
 #### Defined in
 
-[src/types/globals.ts:16](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/globals.ts#L16)
+[src/types/globals.ts:16](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/globals.ts#L16)
 
 ___
 
@@ -90,7 +90,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:143](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L143)
+[src/types/models.ts:143](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L143)
 
 ___
 
@@ -100,7 +100,7 @@ ___
 
 #### Defined in
 
-[src/types/route-requests.ts:13](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-requests.ts#L13)
+[src/types/route-requests.ts:13](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/route-requests.ts#L13)
 
 ___
 
@@ -110,7 +110,7 @@ ___
 
 #### Defined in
 
-[src/types/route-requests.ts:21](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-requests.ts#L21)
+[src/types/route-requests.ts:21](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/route-requests.ts#L21)
 
 ___
 
@@ -127,7 +127,7 @@ ___
 
 #### Defined in
 
-[src/types/route-requests.ts:25](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/route-requests.ts#L25)
+[src/types/route-requests.ts:25](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/route-requests.ts#L25)
 
 ___
 
@@ -143,7 +143,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:102](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L102)
+[src/types/models.ts:102](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L102)
 
 ___
 
@@ -153,7 +153,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:59](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L59)
+[src/types/models.ts:59](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L59)
 
 ___
 
@@ -163,7 +163,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:56](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L56)
+[src/types/models.ts:56](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L56)
 
 ___
 
@@ -173,7 +173,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:14](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L14)
+[src/types/models.ts:14](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L14)
 
 ___
 
@@ -183,7 +183,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:57](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L57)
+[src/types/models.ts:57](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L57)
 
 ___
 
@@ -193,7 +193,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:8](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L8)
+[src/types/models.ts:8](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L8)
 
 ___
 
@@ -203,7 +203,7 @@ ___
 
 #### Defined in
 
-[src/types/models.ts:13](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/models.ts#L13)
+[src/types/models.ts:13](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/models.ts#L13)
 
 ___
 
@@ -219,4 +219,4 @@ ___
 
 #### Defined in
 
-[src/types/globals.ts:7](https://github.com/seamapi/seamapi-javascript/blob/main/src/types/globals.ts#L7)
+[src/types/globals.ts:7](https://github.com/hello-seam/seamapi-javascript/blob/main/src/types/globals.ts#L7)

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,10 @@ import { ErroredAPIResponse, SuccessfulAPIResponse } from "./types/globals"
 class Seam extends Routes {
   private client: AxiosInstance
 
-  constructor(apiKey?: string, endpoint = "https://connect.getseam.com") {
+  constructor(
+    apiKey?: string,
+    endpoint = process.env.SEAM_API_URL || "https://connect.getseam.com"
+  ) {
     super()
 
     if (!apiKey) {


### PR DESCRIPTION
- switch to ssh cloning of submodule
- fixes based on testing
- update tests submodule
- fix access code querying, update readme
- BREAKING CHANGE: commit to fix release, fix README header
- update readme to attempt release
- last try at major release
- chore(release): 2.0.0 [skip ci]
- remove log line
- fix action attempt failures not throwing
- Add CLI framework & handlers for connected accounts, action attempts
- chore(release): 2.0.1 [skip ci]
- Refactor into separate files
- Add handler for access-codes
- Add handler for connect webview
- Add handlers for devices and locks
- Add handler for workspaces
- Tighten types
- Set up packaging
- Update README
- Split off entry point
- Build standalone binaries during release
- chore(release): 2.1.0 [skip ci]
- Import commands directly to support bundling
- Add bundle for browser
- Fix formatting
- Add shim for process.stdout.write
- Add export so both downstream Webpack and TS are happy
- Wait for command to execute, add intro to help message
- Fix doc references
- Trim command prefix
- chore(release): 2.2.0 [skip ci]
- Fix cache dir for CI builds
- feat: bump version
- chore(release): 2.3.0 [skip ci]
- fix: move typed-emitter to prod dependencies
- chore(release): 2.3.1 [skip ci]
- Update tests
- fix: clean up types
- chore(release): 2.3.2 [skip ci]
- support for environment-loaded seam api url
