### PR TITLE
Better formatting of validation errors

### DIFF
--- a/src/lib/api-error.ts
+++ b/src/lib/api-error.ts
@@ -50,6 +50,10 @@ export class SeamMalformedInputError extends Error {
   }
 
   toString() {
-    return `SeamMalformedInputError: ${JSON.stringify(this.validationErrors)}`
+    return `SeamMalformedInputError: ${JSON.stringify(
+      this.validationErrors,
+      null,
+      2
+    )}`
   }
 }

--- a/src/lib/api-error.ts
+++ b/src/lib/api-error.ts
@@ -42,7 +42,7 @@ export class SeamActionAttemptError extends Error {
 
 export class SeamMalformedInputError extends Error {
   constructor(public validationErrors: Record<string, unknown>) {
-    super("Malformed input")
+    super(`Malformed input: ${JSON.stringify(validationErrors, null, 2)}`)
 
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, this.constructor)


### PR DESCRIPTION
Closes https://github.com/seamapi/seamapi-javascript/issues/30.

@seveibar does this look better or did you have something else in mind? `.toString()` now looks like:

```
SeamMalformedInputError: {␊
  "_errors": [],␊
  "device_id": {␊
    "_errors": [␊
      "Invalid uuid"␊
    ]␊
  }␊
}
```
